### PR TITLE
Do not filter non-binary files in directories using lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
-"static/downloads/**/*" filter=lfs diff=lfs merge=lfs -text
-"static/img/**/*" filter=lfs diff=lfs merge=lfs -text
+*.html !filter !diff !merge text
+*.md !filter !diff !merge text
+*.svg !filter !diff !merge text
+static/downloads/**/* filter=lfs diff=lfs merge=lfs -text
+static/img/**/* filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Add rules to `.gitattributes` which allow git to treat non-image files in the `/img/` directory as text files.